### PR TITLE
changes for magicgui 0.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     install_requires=[
         'stardist>=0.7.0',
         'tensorflow',
-        'napari>=0.4.8',
-        'magicgui>=0.2.9'
+        'napari>=0.4.9',
+        'magicgui>=0.3.0'
     ],
 )

--- a/stardist_napari/_dock_widget.py
+++ b/stardist_napari/_dock_widget.py
@@ -76,7 +76,8 @@ def plugin_wrapper():
                 source = Signal.sender()
                 emitter = Signal.current_emitter()
                 if debug:
-                    print(f"{emitter}: {source} = {args!r}")
+                    # print(f"{emitter}: {source} = {args!r}")
+                    print(f"{str(emitter.name).upper()}: {source.name} = {args!r}")
                 return handler(*args)
             for widget in widgets:
                 widget.changed.connect(wrapper)
@@ -552,7 +553,7 @@ def plugin_wrapper():
     @change_handler(plugin.axes, init=False)
     def _axes_change(value: str):
         if value != value.upper():
-            with plugin.axes.changed.blocker():
+            with plugin.axes.changed.blocked():
                 plugin.axes.value = value.upper()
         image = plugin.image.value
         try:

--- a/tests/example_napari.py
+++ b/tests/example_napari.py
@@ -3,12 +3,10 @@ import numpy as np
 from stardist.models import Config3D, StarDist3D
 from stardist.data import  test_image_nuclei_2d, test_image_nuclei_3d
 from csbdeep.utils import normalize
+import napari
 
 
 def show_surface():
-
-    import napari
-    
     model = _model3d()
     img, mask = test_image_nuclei_3d(return_mask=True)
     x = normalize(img, 1, 99.8)
@@ -25,35 +23,32 @@ def show_surface():
 
     surface = surface_from_polys(polys)
 
-    with napari.gui_qt(): 
-        # add the surface
-        viewer = napari.view_image(img) 
-        viewer.add_surface(surface) 
+    # add the surface
+    viewer = napari.view_image(img) 
+    viewer.add_surface(surface) 
 
 
 def show_napari_2d():
-    import napari
     x = test_image_nuclei_2d()
 
-    with napari.gui_qt():
-        viewer =  napari.Viewer()
+    viewer =  napari.Viewer()
 
-        viewer.add_image(x)
+    viewer.add_image(x)
 
-        viewer.window.add_plugin_dock_widget('StarDist')
+    viewer.window.add_plugin_dock_widget('StarDist')
 
 def show_napari_3d():
-    import napari
     x = test_image_nuclei_3d()
 
-    with napari.gui_qt():
-        viewer =  napari.Viewer()
+    viewer =  napari.Viewer()
 
-        viewer.add_image(x)
+    viewer.add_image(x)
 
-        viewer.window.add_plugin_dock_widget('StarDist')
+    viewer.window.add_plugin_dock_widget('StarDist')
         
 if __name__ == '__main__':
 
     show_napari_2d()
-
+    
+    if 'run' in sys.argv:
+        napari.run()

--- a/tests/example_napari.py
+++ b/tests/example_napari.py
@@ -6,49 +6,42 @@ from csbdeep.utils import normalize
 import napari
 
 
-def show_surface():
-    model = _model3d()
-    img, mask = test_image_nuclei_3d(return_mask=True)
-    x = normalize(img, 1, 99.8)
-    labels, polys = model.predict_instances(x)
+# def show_surface():
+#     model = StarDist3D.from_pretrained('3D_demo')
+#     img, mask = test_image_nuclei_3d(return_mask=True)
+#     x = normalize(img, 1, 99.8)
+#     labels, polys = model.predict_instances(x)
 
-    def surface_from_polys(polys): 
-        from stardist.geometry import dist_to_coord3D 
-        faces = polys["rays_faces"] 
-        coord = dist_to_coord3D(polys["dist"], polys["points"], polys["rays_vertices"]) 
-        faces = np.concatenate([faces+coord.shape[1]*i for i in np.arange(len(coord))]) 
-        vertices = np.concatenate(coord, axis = 0) 
-        values = np.concatenate([np.random.rand()*np.ones(len(c)) for c in coord]) 
-        return (vertices,faces,values) 
+#     def surface_from_polys(polys):
+#         from stardist.geometry import dist_to_coord3D
+#         faces = polys["rays_faces"]
+#         coord = dist_to_coord3D(polys["dist"], polys["points"], polys["rays_vertices"])
+#         faces = np.concatenate([faces+coord.shape[1]*i for i in np.arange(len(coord))])
+#         vertices = np.concatenate(coord, axis = 0)
+#         values = np.concatenate([np.random.rand()*np.ones(len(c)) for c in coord])
+#         return (vertices,faces,values)
 
-    surface = surface_from_polys(polys)
+#     surface = surface_from_polys(polys)
 
-    # add the surface
-    viewer = napari.view_image(img) 
-    viewer.add_surface(surface) 
+#     # add the surface
+#     viewer = napari.view_image(img)
+#     viewer.add_surface(surface)
 
 
 def show_napari_2d():
     x = test_image_nuclei_2d()
-
     viewer =  napari.Viewer()
-
     viewer.add_image(x)
-
     viewer.window.add_plugin_dock_widget('StarDist')
 
 def show_napari_3d():
     x = test_image_nuclei_3d()
-
     viewer =  napari.Viewer()
-
     viewer.add_image(x)
-
     viewer.window.add_plugin_dock_widget('StarDist')
-        
+
 if __name__ == '__main__':
 
     show_napari_2d()
-    
     if 'run' in sys.argv:
         napari.run()


### PR DESCRIPTION
magicgui 0.3.0 prerelase is out now... and it comes with some changes to the event system.
(See https://github.com/napari/magicgui/pull/253 for details)

while this plugin will still be compatible with magicgui >=0.3.0 it will have a lot of warnings.  This PR contains the changes needed to avoid the warnings.  (in magicgui 0.4.0 it will error)

(Note: don't merge this until magicgui comes out of pre-release ... you can use `pip install --pre magicgui` to test)