### PR TITLE
Proposal for plugin analytics

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,6 @@ setup(
         'tensorflow-macos;  platform_system=="Darwin" and platform_machine=="arm64"',
         "napari>=0.4.13",
         "magicgui>=0.3.0",
+        "plausible-events @ git+https://github.com/uschmidt83/plausible-events.git",  # temporary
     ],
 )


### PR DESCRIPTION
This is adding *privacy-conscious* plugin analytics via [plausible.io](https://plausible.io) (using the [plausible-events](https://github.com/uschmidt83/plausible-events) package).
The recorded data is publicly visible at https://plausible.io/stardist-napari.

**Note:** Analytics are enabled by default right now, and there's no option to turn them off. This won't stay that way.