### PR TITLE
Add tensorflow-metal as req on macOS/arm64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "stardist>=0.8.3",
         'tensorflow;  platform_system!="Darwin" or platform_machine!="arm64"',
         'tensorflow-macos;  platform_system=="Darwin" and platform_machine=="arm64"',
+        'tensorflow-metal;  platform_system=="Darwin" and platform_machine=="arm64"',
         "napari>=0.4.13",
         "magicgui>=0.4.0",
     ],


### PR DESCRIPTION
`tensorflow-macos` is now pip installable without Apple conda channel dependancies.
`tensorflow-metal` is also pip installable with no issues and on larger images it can offer ~4x speedup on vanilla M1 and every arm64 macOS machine will have a Metal GPU, so it seems safe to bundle these requirements to give a napari GUI user a big boost in speed on Apple Silicon.
(I've been using StarDist/stardist-napari with `tensorflow-macos` for close to a year now and it's worked exceptionally well.)